### PR TITLE
fix sum() implementation to match the paper

### DIFF
--- a/streamhist/histogram.py
+++ b/streamhist/histogram.py
@@ -347,29 +347,12 @@ class StreamHist(object):
             ss = 0.0  # Sum is zero!
         elif x >= self._max:
             ss = float(self.total)
-        elif x == self.bins[-1].value:
-            # Shortcut for when i == max bin (see Steps 3-6)
-            last = self.bins[-1]
-            ss = float(self.total) - (float(last.count) / 2.0)
-        # elif x <= self.bins[0].value:
-        #     # Shortcut for when i == min bin (see Steps 3-6)
-        #     first = self.bins[0]
-        #     ss = float(first.count) / 2.0
         else:
-            bin_i = self.floor(x)
-            if bin_i is None:
-                bin_i = Bin(value=self._min, count=0)
-            bin_i1 = self.higher(x)
-            if bin_i1 is None:
-                bin_i1 = Bin(value=self._max, count=0)
-            if bin_i.value == self._min:
-                prev_sum = self.bins[0].count / 2.0
-            else:
-                temp = bin_sums(self.bins, less=x)
-                if len(temp):
-                    prev_sum = sum(temp)
-                else:
-                    prev_sum = 0.0
+            i = self.bins.bisect_key_right(x) - 1  # rightmost bin lte x
+            bin_i = self.bins[i] if i >= 0 else Bin(self._min, 0)
+            bin_i1 = self.bins[i+1] if i+1 < len(self.bins) else Bin(self._max, 0)
+            prev_sum = sum(bin.count for bin in self.bins[:i])
+            prev_sum += bin_i.count / 2
             ss = _compute_sum(x, bin_i, bin_i1, prev_sum)
         return ss
 

--- a/streamhist/test/test_histogram.py
+++ b/streamhist/test/test_histogram.py
@@ -269,6 +269,24 @@ def test_sum():
     assert about(h.sum(0), points/2.0, points/50.0)
 
 
+def test_paper_example():
+    """Test Appendix A example from Ben-Haim paper."""
+    from numpy import allclose
+    h = StreamHist(maxbins=5)
+    h.update((23,19,10,16,36,2,9))
+    assert allclose(
+        [(bin.value, bin.count) for bin in h.bins],
+        [(2,1), (9.5,2), (17.5,2), (23,1), (36,1)])
+    h2 = StreamHist(maxbins=5)
+    h2.update((32,30,45))
+    h3 = h + h2
+    assert allclose(
+        [(bin.value, bin.count) for bin in h3.bins],
+        [(2,1), (9.5,2), (19.33,3), (32.67,3), (45,1)],
+        rtol=1e-3)
+    assert about(h3.sum(15), 3.275, 1e-3)
+
+
 def test_quantiles():
     points = 10000
     h = StreamHist()


### PR DESCRIPTION
Previously the output was not monotonically increasing.

Also the implementation performance is improved (1 bisect call rather
than 2), and code simplified (removing edge case optimizations).

Added test covering paper's example.

Related to #7 .