### PR TITLE
require pytest for tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ Testing
 
 ``streamhist`` comes with a relatively comprehensive range of tests,
 including unit tests and regression tests. To run the tests, you can use
-``py.test`` or ``nosetests``, which can both be installed via ``pip``
+``pytest``, which can be installed via ``pip``
 using the ``recommended.txt`` file (note, this will also install
 ``numpy``, ``matplotlib``, and ``IPython`` which are used for tests and
 examples):
@@ -56,7 +56,7 @@ examples):
 .. code:: bash
 
     pip install -r recommended.txt
-    nosetests streamhist
+    pytest streamhist
 
 Features
 ========

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -48,7 +48,7 @@ Testing
 
 ``streamhist`` comes with a relatively comprehensive range of tests,
 including unit tests and regression tests. To run the tests, you can use
-``py.test`` or ``nosetests``, which can both be installed via ``pip``
+``pytest``, which can be installed via ``pip``
 using the ``recommended.txt`` file (note, this will also install
 ``numpy``, ``matplotlib``, and ``IPython`` which are used for tests and
 examples):
@@ -56,7 +56,7 @@ examples):
 .. code:: bash
 
     pip install -r recommended.txt
-    nosetests streamhist
+    pytest streamhist
 
 Features
 ========

--- a/examples/examples.ipynb
+++ b/examples/examples.ipynb
@@ -46,11 +46,11 @@
    "source": [
     "# Testing\n",
     "\n",
-    "`streamhist` comes with a relatively comprehensive range of tests, including unit tests and regression tests. To run the tests, you can use `py.test` or `nosetests`, which can both be installed via `pip` using the `recommended.txt` file (note, this will also install `numpy`, `matplotlib`, and `IPython` which are used for tests and examples):\n",
+    "`streamhist` comes with a relatively comprehensive range of tests, including unit tests and regression tests. To run the tests, you can use `pytest`, which can be installed via `pip` using the `recommended.txt` file (note, this will also install `numpy`, `matplotlib`, and `IPython` which are used for tests and examples):\n",
     "\n",
     "```bash\n",
     "pip install -r recommended.txt\n",
-    "nosetests streamhist\n",
+    "pytest streamhist\n",
     "```"
    ]
   },

--- a/recommended.txt
+++ b/recommended.txt
@@ -1,4 +1,5 @@
 # Examples and tests
+pytest
 numpy
 matplotlib
 ipython[notebook]>=3.0.0


### PR DESCRIPTION
There was already a pytest dependency in the tests, so this
makes it official.  Subsequent changes will employ pytest for
parameterization, so nosetest will no longer work.